### PR TITLE
Offset drops to side clicked to avoid collision weirdness

### DIFF
--- a/src/main/java/epicsquid/blockcraftery/tile/TileEditableBlock.java
+++ b/src/main/java/epicsquid/blockcraftery/tile/TileEditableBlock.java
@@ -43,7 +43,8 @@ public class TileEditableBlock extends TileBase {
           markDirty();
           if (!player.capabilities.isCreativeMode && !ConfigManager.freeDecoration) {
             if (!world.isRemote && !player.capabilities.isCreativeMode && !stack.isEmpty()) {
-              world.spawnEntity(new EntityItem(world, pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, stack));
+              BlockPos offset = pos.offset(side);
+              world.spawnEntity(new EntityItem(world, offset.getX() + 0.5, offset.getY() + 0.5, offset.getZ() + 0.5, stack));
             }
             this.stack = player.getHeldItemMainhand().copy();
             stack.setCount(1);
@@ -78,7 +79,8 @@ public class TileEditableBlock extends TileBase {
       return true;
     } else if (player.isSneaking() && player.getHeldItemMainhand().isEmpty()) {
       if (!world.isRemote && !player.capabilities.isCreativeMode && !ConfigManager.freeDecoration) {
-        world.spawnEntity(new EntityItem(world, pos.getX() + 0.5, pos.getY() + 0.5, pos.getZ() + 0.5, stack));
+        BlockPos offset = pos.offset(side);
+        world.spawnEntity(new EntityItem(world, offset.getX() + 0.5, offset.getY() + 0.5, offset.getZ() + 0.5, stack));
       }
       stack = ItemStack.EMPTY;
       this.state = Blocks.AIR.getDefaultState();


### PR DESCRIPTION
When drops are spawned inside the block space of the frame block, they can glitch out and throw themselves everywhere. Offsetting them like this avoids that.